### PR TITLE
fix: fixing issue where memory reallocation can cause memory leaks

### DIFF
--- a/src/winapi.rs
+++ b/src/winapi.rs
@@ -12,7 +12,7 @@ pub struct Connection;
 impl ConnectionTrait for Connection {
     fn new() -> Result<Self> { Ok(Self) }
     fn window_titles(&self) -> Result<Vec<String>> {
-        let state: Box<Vec<String>> = Box::new(Vec::new());
+        let state: Box<Vec<String>> = Box::new(Vec::with_capacity(1000));
         let ptr = Box::into_raw(state);
         let state;
         unsafe {


### PR DESCRIPTION
reserves a chunk of memory for the initial vector to prevent the pointer from being reallocated (it may point to an old address which we told rust we would manage, and is now gone)